### PR TITLE
config / dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2332,7 +2332,8 @@
     "deep-diff": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -9085,6 +9086,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "dev": true,
       "requires": {
         "deep-diff": "0.3.8"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-tagsinput": "3.19.0",
     "reactstrap": "5.0.0-alpha.4",
     "redux": "3.7.2",
-    "redux-logger": "3.0.6",
     "redux-thunk": "2.2.0"
   },
   "scripts": {
@@ -40,6 +39,7 @@
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.5.1",
-    "redux-devtools": "3.4.1"
+    "redux-devtools": "3.4.1",
+    "redux-logger": "3.0.6"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter, Route } from 'react-router-dom';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
-import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 import eventsReducer from './Events/List/duck';
 import eventReducer from './Events/Details/duck';
@@ -22,6 +21,14 @@ import registerServiceWorker from './registerServiceWorker';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
+const middlewares = [];
+
+if (process.env.NODE_ENV === 'development') {
+    const { logger } = require(`redux-logger`);
+    middlewares.push(logger);
+}
+middlewares.push(thunk);
+
 const reducer = combineReducers({
     events: eventsReducer,
     event: eventReducer,
@@ -33,7 +40,7 @@ const reducer = combineReducers({
     subscriptions: subscriptionsReducer,
 });
 
-const store = createStore(reducer, composeEnhancers(applyMiddleware(thunk, logger)));
+const store = createStore(reducer, composeEnhancers(applyMiddleware(...middlewares)));
 
 const app = (
     <Provider store={store}>
@@ -43,5 +50,5 @@ const app = (
     </Provider>
 );
 
-ReactDOM.render( app, document.getElementById('root'));
+ReactDOM.render(app, document.getElementById('root'));
 registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const middlewares = [];
 
+// disable redux-logger in production mode
 if (process.env.NODE_ENV === 'development') {
     const { logger } = require(`redux-logger`);
     middlewares.push(logger);


### PR DESCRIPTION
Enable redux-logger only on development mode with **process.env.NODE_ENV**  

Read more about **process.env.NODE_ENV** here: [https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables)