### PR TITLE
Fix / search details page

### DIFF
--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -47,6 +47,7 @@ class InsidePage extends Component {
             error: null,
             isNotAuth: false,
             eventIsInWishList: false,
+            updateCount: 0,
         };
     }
 
@@ -99,6 +100,7 @@ class InsidePage extends Component {
         const successCallback = () => {
             this.setState({ isUpdated: true });
             this.setState({ eventIsInWishList: true });
+            this.setState({ updateCount: 1 });
 
             this.handleDelayedMessageReset();
         };
@@ -245,7 +247,6 @@ class InsidePage extends Component {
                 <img
                     className="mx-auto mb-5"
                     src={data.pictureUrl}
-
                     alt={data.name}
                 />
 
@@ -260,9 +261,9 @@ class InsidePage extends Component {
                     </div>
 
                     <div className="mb-4 text-bottom d-flex">
-                        <HeartFullIcon />
+                        <HeartFullIcon style={{ cursor: 'auto' }} />
                         <h5 className="ml-2 font-weight-normal d-inline">Going:
-                            <span className="text-secondary ml-1">{data.attendees.length}</span>
+                            <span className="text-secondary ml-1">{data.attendees.length + this.state.updateCount}</span>
                         </h5>
                     </div>
                     <div dangerouslySetInnerHTML={this.renderDescription()} />

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -269,6 +269,7 @@ class InsidePage extends Component {
                     <a
                         className="btn btn-secondary"
                         href={data.website}
+                        target="_blank"
                     >Go to website
                     </a>
                 </div>

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -171,7 +171,7 @@ class InsidePage extends Component {
         this.props.event.data.speakers.map((speaker, key) => {
             renderImages.push(
                 <div className="d-inline" key={key} >
-                    <PopoverItem key={key} item={speaker} id={key}>
+                    <PopoverItem parentComponent="eventDetails" key={key} item={speaker} id={key}>
                         <img
                             className="rounded-circle mr-2"
                             key={key}
@@ -246,6 +246,7 @@ class InsidePage extends Component {
             <div className="container__register mx-auto pt-5 pb-5 d-flex flex-column">
                 <img
                     className="mx-auto mb-5"
+                    width="100%"
                     src={data.pictureUrl}
                     alt={data.name}
                 />

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -171,7 +171,7 @@ class InsidePage extends Component {
         this.props.event.data.speakers.map((speaker, key) => {
             renderImages.push(
                 <div className="d-inline" key={key} >
-                    <PopoverItem parentComponent="eventDetails" key={key} item={speaker} id={`p${key}`}>
+                    <PopoverItem shouldTogglePopover key={key} item={speaker} id={`p${key}`}>
                         <img
                             className="rounded-circle mr-2"
                             key={key}

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -185,15 +185,31 @@ class InsidePage extends Component {
         return renderImages;
     }
 
+    tagClicked = (event) => {
+        this.props.history.push({
+            pathname: `/search/${event.target.textContent}`,
+            state: {
+                wishListData: {},
+            },
+        })
+    }
+
     renderTags() {
         const renderTags = [];
+        const style = {
+            cursor: 'pointer',
+        };
+
         this.props.event.data.tags.map((tag) => {
             renderTags.push(<span
                 key={tag}
                 className="badge badge-pill badge-light mr-2"
+                style={style}
+                onClick={
+                    this.tagClicked
+                }
             >{tag}
             </span>);
-            return tag;
         });
         return renderTags;
     }
@@ -229,6 +245,7 @@ class InsidePage extends Component {
                 <img
                     className="mx-auto mb-5"
                     src={data.pictureUrl}
+
                     alt={data.name}
                 />
 

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -171,7 +171,7 @@ class InsidePage extends Component {
         this.props.event.data.speakers.map((speaker, key) => {
             renderImages.push(
                 <div className="d-inline" key={key} >
-                    <PopoverItem parentComponent="eventDetails" key={key} item={speaker} id={key}>
+                    <PopoverItem parentComponent="eventDetails" key={key} item={speaker} id={`p${key}`}>
                         <img
                             className="rounded-circle mr-2"
                             key={key}

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -229,8 +229,6 @@ class InsidePage extends Component {
                 <img
                     className="mx-auto mb-5"
                     src={data.pictureUrl}
-                    width="381"
-                    height="388"
                     alt={data.name}
                 />
 

--- a/src/Events/Details/index.js
+++ b/src/Events/Details/index.js
@@ -57,6 +57,15 @@ class InsidePage extends Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (this.props.alias !== nextProps.alias) {
+            this.props.fetchConferenceDeatails(nextProps.alias);
+            if (this.props.auth.isAuthenticated) {
+                this.props.fetchWishListIfNeeded(this.props.auth.token);
+            }
+        }
+    }
+
     isEventInWhishlist = (_eventID, _wishlist) => {
         const event = _.find(_wishlist.data, e => e.id === _eventID);
 

--- a/src/Events/WishList/Attend.js
+++ b/src/Events/WishList/Attend.js
@@ -66,7 +66,6 @@ class Attend extends Component {
         return (
             <PopoverItem
                 id={this.props.id}
-                parentComponent="attend"
                 item={{ name: 'Wanna go' }}
                 onClick={this.handleToggleActive}
                 isActive={this.props.isActive}

--- a/src/Events/WishList/Attend.js
+++ b/src/Events/WishList/Attend.js
@@ -66,6 +66,7 @@ class Attend extends Component {
         return (
             <PopoverItem
                 id={this.props.id}
+                parentComponent="attend"
                 item={{ name: 'Wanna go' }}
                 onClick={this.handleToggleActive}
                 isActive={this.props.isActive}

--- a/src/common/HeartFullIcon.js
+++ b/src/common/HeartFullIcon.js
@@ -1,9 +1,16 @@
 import React from 'react';
 
 const heartFullIcon = ({ style }) => {
-    const styling = {
-        cursor: 'pointer',
-    };
+    let cursor;
+    // Receive style from props only when cursor shouldn't be pointer
+    if (typeof style === 'undefined') {
+        cursor = {
+            cursor: 'pointer',
+        };
+    } else {
+        cursor = style;
+    }
+
     return (
         <svg
             width="20px"
@@ -12,7 +19,7 @@ const heartFullIcon = ({ style }) => {
             version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
-            style={typeof style === 'undefined' ? styling : style}
+            style={cursor}
         >
             <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                 <g id="conflist-home-page-logged-in" transform="translate(-986.000000, -677.000000)">

--- a/src/common/HeartFullIcon.js
+++ b/src/common/HeartFullIcon.js
@@ -1,16 +1,6 @@
 import React from 'react';
 
 const heartFullIcon = ({ style }) => {
-    let cursor;
-    // Receive style from props only when cursor shouldn't be pointer
-    if (typeof style === 'undefined') {
-        cursor = {
-            cursor: 'pointer',
-        };
-    } else {
-        cursor = style;
-    }
-
     return (
         <svg
             width="20px"
@@ -19,7 +9,7 @@ const heartFullIcon = ({ style }) => {
             version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
-            style={cursor}
+            style={typeof style === 'undefined' ? { cursor: 'pointer' } : style }
         >
             <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                 <g id="conflist-home-page-logged-in" transform="translate(-986.000000, -677.000000)">

--- a/src/common/HeartFullIcon.js
+++ b/src/common/HeartFullIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const heartFullIcon = () => {
-    const style = {
+const heartFullIcon = ({ style }) => {
+    const styling = {
         cursor: 'pointer',
     };
     return (
@@ -12,7 +12,7 @@ const heartFullIcon = () => {
             version="1.1"
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
-            style={style}
+            style={typeof style === 'undefined' ? styling : style}
         >
             <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
                 <g id="conflist-home-page-logged-in" transform="translate(-986.000000, -677.000000)">

--- a/src/common/PopoverItem.js
+++ b/src/common/PopoverItem.js
@@ -8,7 +8,7 @@ class PopoverItem extends Component {
             name: PropTypes.string,
         }).isRequired,
         id: PropTypes.string.isRequired,
-        parentComponent: PropTypes.string.isRequired,
+        shouldTogglePopover: PropTypes.bool,
         children: PropTypes.object,
 
         // received from parent component Attend
@@ -33,9 +33,9 @@ class PopoverItem extends Component {
     toggle() {
         /**
          * This PopoverItem has two different behaviours depending
-         * on which parent component is called
+         * on shouldTogglePopover prop
          */
-        if (this.props.parentComponent === 'eventDetails') {
+        if (this.props.shouldTogglePopover) {
             this.setState({
                 popoverOpen: !this.state.popoverOpen,
             });
@@ -43,7 +43,7 @@ class PopoverItem extends Component {
 
         /**
          * Call OnClick function from parent component Attend to change isActive icon,
-         * and close Popover for Card Attend PopoverItem
+         * and close Popover on Card Attend PopoverItem
          */
         if (!this.state.popoverOpen) {
             this.props.onClick();

--- a/src/common/PopoverItem.js
+++ b/src/common/PopoverItem.js
@@ -7,7 +7,7 @@ class PopoverItem extends Component {
         item: PropTypes.shape({
             name: PropTypes.string,
         }).isRequired,
-        id: PropTypes.number.isRequired,
+        id: PropTypes.string.isRequired,
         parentComponent: PropTypes.string.isRequired,
         children: PropTypes.object,
 
@@ -39,7 +39,7 @@ class PopoverItem extends Component {
 
         /**
          * Call OnClick function from parent component Attend to change isActive icon,
-         * and close Popover
+         * and close Popover for Card Attend PopoverItem
          */
         if (!this.state.popoverOpen) {
             this.props.onClick();

--- a/src/common/PopoverItem.js
+++ b/src/common/PopoverItem.js
@@ -8,6 +8,7 @@ class PopoverItem extends Component {
             name: PropTypes.string,
         }).isRequired,
         id: PropTypes.number.isRequired,
+        parentComponent: PropTypes.string.isRequired,
         children: PropTypes.object,
 
         // received from parent component Attend
@@ -30,6 +31,12 @@ class PopoverItem extends Component {
     }
 
     toggle() {
+        if (this.props.parentComponent === 'eventDetails') {
+            this.setState({
+                popoverOpen: !this.state.popoverOpen,
+            });
+        }
+
         /**
          * Call OnClick function from parent component Attend to change isActive icon,
          * and close Popover
@@ -54,9 +61,10 @@ class PopoverItem extends Component {
     }
 
     render() {
+        const style = { cursor: 'pointer' };
         return (
             <span>
-                <span role="button" id={'Popover-' + this.props.id} onClick={this.toggle}>
+                <span style={style} role="button" id={'Popover-' + this.props.id} onClick={this.toggle}>
                     {this.props.children}
                 </span>
                 <Popover

--- a/src/common/PopoverItem.js
+++ b/src/common/PopoverItem.js
@@ -31,6 +31,10 @@ class PopoverItem extends Component {
     }
 
     toggle() {
+        /**
+         * This PopoverItem has two different behaviours depending
+         * on which parent component is called
+         */
         if (this.props.parentComponent === 'eventDetails') {
             this.setState({
                 popoverOpen: !this.state.popoverOpen,


### PR DESCRIPTION
Change: 
Change 'Going' count for event attendees on event details page when clicking on 'wanna go' button,
remove cursor pointer from heartFullIcon,
go to search page on tag click from event details page,
image with full width,
popoverItem on speaker on event details page.


Fix bug with selecting new conference name from search bar on details page