### PR TITLE
Fix / Search

### DIFF
--- a/src/Search/Search.css
+++ b/src/Search/Search.css
@@ -41,6 +41,8 @@
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   z-index: 2;
+  overflow-y: auto;
+  max-height: 600px;
 }
 
 .react-tagsinput .react-autosuggest__suggestions-container--open {

--- a/src/Search/index.js
+++ b/src/Search/index.js
@@ -91,6 +91,7 @@ class Search extends Component {
 
         // Section title, when multiSection={true}.
         renderSectionTitle = (section) => {
+            if (section.data.length === 0) { return; }
             return (
                 <strong>{section.title}</strong>
             );


### PR DESCRIPTION
Fixes search bar issue when suggestions list is too long with scrollable container and max-width.
Shows title of suggestions only when there is data fetched for this suggestion title.

<img width="368" alt="screenshot 2018-11-01 at 17 35 56" src="https://user-images.githubusercontent.com/29689645/47862019-d92e7e00-ddfc-11e8-8315-ebe5e6ca37e8.png">

